### PR TITLE
ci: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 6 * * 1" # Monday at 6:30 UTC
+
+jobs:
+  analyze:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds CodeQL static analysis, copied verbatim from `now-sdk-ext-mcp` (javascript-typescript, on push/PR to `main`, plus a weekly Monday schedule).

Neither this repository nor its predecessor ever ran CodeQL.

## Why this lands before branch protection

`now-sdk-ext-core` demonstrated the failure mode this sequencing avoids: its `Main Branch Protection` ruleset includes a `code_scanning` rule requiring CodeQL results, but the repository had **no CodeQL workflow**, so `GET /code-scanning/analyses` returned *"no analysis found"* and the requirement was unsatisfiable. Every PR to `main` sat in `mergeStateStatus: BLOCKED` no matter how green its checks were — which is why exactly one PR had ever merged there.

Landing the workflow first means a `code_scanning` rule on this repo will have results to evaluate from day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MggifJUgccB2gu3NsPbtUV