### PR TITLE
fix: stop logging credentials, and make --log-level work

### DIFF
--- a/src/common/authenticated-command.ts
+++ b/src/common/authenticated-command.ts
@@ -65,8 +65,12 @@ protected instance!:ServiceNowInstance;
     this.flags = flags as Flags<T>
     this.args = args as Args<T>
 
-    this.logger = LogFactory.createLogger(this.ctor.name, this.flags.logLevel || 'info');
-    this.authLogger = LogFactory.createLogger("AuthenticatedCommand", this.flags.logLevel || 'info');
+    // The flag is declared as 'log-level' in baseFlags, so oclif keys the parsed
+    // value under that exact name. Reading `flags.logLevel` always yielded
+    // undefined, silently pinning every command to 'info'.
+    const logLevel = (this.flags['log-level'] as string | undefined) || 'info';
+    this.logger = LogFactory.createLogger(this.ctor.name, logLevel);
+    this.authLogger = LogFactory.createLogger("AuthenticatedCommand", logLevel);
     // const wrapper:CredentialWrapper = new CredentialWrapper();
     // const credential:Creds = await (flags.auth ? wrapper.getStoredCredentialsByAlias(flags.auth) : wrapper.getStoredCredentialsByAlias( 'fluent-default'));
     // const credentialArgs = {"_": "get-credentials", auth: flags.auth || "fluent-default"};

--- a/src/common/authenticated-command.ts
+++ b/src/common/authenticated-command.ts
@@ -71,17 +71,20 @@ protected instance!:ServiceNowInstance;
     // const credential:Creds = await (flags.auth ? wrapper.getStoredCredentialsByAlias(flags.auth) : wrapper.getStoredCredentialsByAlias( 'fluent-default'));
     // const credentialArgs = {"_": "get-credentials", auth: flags.auth || "fluent-default"};
    
-    const credential = await getCredentials(flags.auth || "fluent-default");
-    this.authLogger.debug("Credentials Received: ", credential);
+    const alias = flags.auth || "fluent-default";
+    const credential = await getCredentials(alias);
+    // Never log `credential` or any object containing it (e.g. snSettings) — it
+    // holds the ServiceNow password/token, and these lines run at --log-level
+    // debug, which would write it to the terminal and to CI logs.
+    this.authLogger.debug("Credential lookup complete.", {alias, found: Boolean(credential)});
     if(credential){
        const snSettings:ServiceNowSettingsInstance = {
             alias: flags.auth,
            credential
         }
-        this.authLogger.debug("SN auth settings to instantiate ServiceNowInstance object: ", snSettings);
         this.instance = new ServiceNowInstance(snSettings);
     }else{
-        this.authLogger.error("Either credential not found or no credentials created.", {args: this.args, flags: this.flags});
+        this.authLogger.error("Either credential not found or no credentials created.", {alias});
     }
 
   }

--- a/test/common/authenticated-command-unit.test.ts
+++ b/test/common/authenticated-command-unit.test.ts
@@ -35,6 +35,17 @@ describe('AuthenticatedCommand - Unit Tests', () => {
       const logLevelFlag = AuthenticatedCommand.baseFlags['log-level'] as any
       expect(logLevelFlag.helpGroup).toBe('GLOBAL')
     })
+
+    // Regression guard. init() used to read `this.flags.logLevel`, but oclif keys
+    // parsed flags by their declared name — 'log-level'. That read always yielded
+    // undefined, so every command silently fell back to 'info' and --log-level
+    // did nothing. If the flag is ever renamed to a camelCase key, this fails and
+    // the read site in init() must be updated to match.
+    it('should declare log-level in kebab-case only, never as logLevel', () => {
+      const flagNames = Object.keys(AuthenticatedCommand.baseFlags)
+      expect(flagNames).toContain('log-level')
+      expect(flagNames).not.toContain('logLevel')
+    })
   })
 
   describe('JSON flag support', () => {


### PR DESCRIPTION
Two ordered fixes in `src/common/authenticated-command.ts`, the base class all 67 commands extend.

## 1. Credentials were being written to the log

`init()` logged the credential object in **three** places, all on every command invocation:

| Line | Call | Problem |
|---|---|---|
| 75 | `debug("Credentials Received: ", credential)` | the credential itself |
| 81 | `debug("SN auth settings ...", snSettings)` | `snSettings` **embeds** `credential` |
| 84 | `error("Either credential not found ...", {args, flags})` | dumps every flag |

Now logs only the alias and a boolean `found`. The middle call is removed outright — it existed to confirm the object handed to `ServiceNowInstance`, which the lookup line already covers without disclosing the secret.

## 2. `--log-level` never worked

`baseFlags` declares the flag as `'log-level'`, so oclif keys the parsed value under that exact name. `init()` read `this.flags.logLevel`, which was **always `undefined`** — every command silently pinned to `info`, and `--log-level debug|trace` did nothing on any of the 67 commands.

## Why the order matters

These are two commits, and the sequence is deliberate. Fixing the flag first would have made the debug path reachable for the first time and converted a latent credential disclosure into an active one. The disclosure is closed first, then the flag is repaired.

A regression guard asserts the flag stays kebab-case-only, so a future rename to a camelCase key fails loudly rather than silently disabling the flag again.

## Verification

- build clean
- **520/520** unit tests pass (519 + the new guard)
- no test asserted on the removed log strings

## Incidental finding

`getCredentials()` **throws** for an unknown alias rather than returning falsy, so the `else` branch that handles "credential not found" is largely unreachable in practice. The plan's separate fail-fast change (replacing that branch's `error()` log with a real `this.error()` exit) should account for this — it is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MggifJUgccB2gu3NsPbtUV