### PR TITLE
docs: tell AI agents to use --cred-store, and fix setup steps that never worked

### DIFF
--- a/docs/ai-agents/CLAUDE.md
+++ b/docs/ai-agents/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-`nex` (`@sonisoft/now-sdk-ext-cli`) is a CLI tool that extends the ServiceNow SDK with 69 commands across 18 topics. It enables programmatic interaction with ServiceNow instances for querying data, executing scripts, managing flows, running tests, deploying applications, and more.
+`nex` (`@sonisoft/now-sdk-ext-cli`) is a CLI tool that extends the ServiceNow SDK with commands across 21 topics. It enables programmatic interaction with ServiceNow instances for querying data, executing scripts, managing flows, running tests, deploying applications, and more.
 
 **Every command requires authentication** via the `--auth <alias>` flag, which specifies the target ServiceNow instance using a pre-configured credential alias.
 
@@ -18,8 +18,56 @@ nex query -t incident --auth dev
 nex flow test -f <id> -o '{}' --auth prod
 
 # Auth aliases are configured via the ServiceNow SDK CLI:
-now-sdk auth add --alias dev --host https://dev12345.service-now.com
+now-sdk auth --add dev12345.service-now.com --alias dev --type oauth
 ```
+
+### Headless sessions: add `--cred-store`
+
+**If you are running without an interactive desktop session — over SSH, from a
+systemd unit, in CI, or as an autonomous agent — add `--cred-store` to every
+command:**
+
+```bash
+nex query -t incident --auth dev --cred-store
+```
+
+The ServiceNow SDK stores credentials in the OS keyring, and a non-interactive
+session cannot unlock it *even running as the same user*. The failure is silent
+and actively misleading — you get:
+
+```
+Could not find stored credentials for alias: dev
+```
+
+which reads as a missing alias rather than a locked keyring, so the obvious next
+step (re-adding the alias) does not help. `--cred-store` reads from
+`@sonisoft/sn-credstore` instead, a store that many concurrent agents can share
+safely.
+
+To avoid passing the flag on every command, set it once in the environment:
+
+```bash
+export SN_CRED_STORE_ENABLE=1
+```
+
+Diagnose which path you are on before assuming credentials are missing:
+
+```bash
+nex auth doctor    # active store, whether the shim is on, what is stored
+nex auth list      # aliases in the credential store
+```
+
+One-time setup, which **must** be run from a desktop session on a TTY because the
+keyring will prompt to unlock:
+
+```bash
+npm install -g @sonisoft/sn-credstore
+sn-credstore import --from keyring
+```
+
+Without `--cred-store` (and without `SN_CRED_STORE_ENABLE`), `nex` uses the OS
+keyring exactly as the stock SDK does. That is the default on purpose, so nothing
+changes for interactive use.
 
 ## Global Flags
 
@@ -30,6 +78,7 @@ These flags are available on every command:
 | `--auth` | `-a` | string | Auth alias for the target ServiceNow instance (required) |
 | `--log-level` | | string | Logging verbosity: `debug`, `info`, `warn`, `error`, `trace` (default: `info`) |
 | `--json` | `-j` | boolean | Output results as structured JSON instead of formatted text |
+| `--cred-store` | | boolean | Read credentials from `@sonisoft/sn-credstore` instead of the OS keyring. **Required in headless sessions** — see Authentication above. |
 
 ## Output Patterns
 
@@ -54,7 +103,7 @@ nex exec global script.js -p '{"table":"incident","query":"active=true"}' --auth
 
 ## Quick Reference
 
-All 69 commands at a glance:
+Every command at a glance:
 
 | Command | Description |
 |---------|-------------|
@@ -69,6 +118,11 @@ All 69 commands at a glance:
 | `nex app uninstall` | Uninstall a ServiceNow application by ID and scope |
 | **ATF** | |
 | `nex atf` | Execute ATF tests or test suites |
+| **Auth** | |
+| `nex auth list` | List credentials in the headless-safe credential store |
+| `nex auth use` | Set the default credential alias |
+| `nex auth delete` | Remove a credential from the store |
+| `nex auth doctor` | Diagnose credential storage |
 | **Attachment** | |
 | `nex attachment get` | Get metadata for a specific attachment |
 | `nex attachment list` | List attachments on a record |
@@ -315,6 +369,74 @@ nex atf -n "Incident Management Tests" --auth dev
 
 # Run a test suite by sys_id with JSON output
 nex atf -s def456abc789012 --json --auth dev
+```
+
+---
+
+### Auth
+
+Manage the headless-safe credential store. These commands read the store
+directly, so they work even when credentials are otherwise unreadable — which is
+what makes `nex auth doctor` useful for diagnosing the failure rather than a
+casualty of it.
+
+`--cred-store` is accepted on these commands and ignored: they always use the
+store.
+
+#### `nex auth list`
+
+List credentials in the store. Secrets are never printed.
+
+| Flag | Short | Type | Required | Default | Description |
+|------|-------|------|----------|---------|-------------|
+| `--json` | `-j` | boolean | no | `false` | Output as JSON |
+
+```bash
+nex auth list
+nex auth list --json
+```
+
+#### `nex auth doctor`
+
+Diagnose credential storage: whether the SDK shim is active, which backend is in
+use, and what is stored. **Run this first when a command reports missing
+credentials** — it distinguishes "no credentials" from "credentials unreadable",
+which every other error conflates.
+
+| Flag | Short | Type | Required | Default | Description |
+|------|-------|------|----------|---------|-------------|
+| `--json` | `-j` | boolean | no | `false` | Output as JSON |
+
+```bash
+nex auth doctor
+nex auth doctor --json
+```
+
+#### `nex auth use`
+
+Set the default credential alias. Commands run without `--auth` use it.
+
+| Flag | Short | Type | Required | Default | Description |
+|------|-------|------|----------|---------|-------------|
+| `<alias>` | | arg | yes | — | Alias to make the default |
+
+```bash
+nex auth use dev
+```
+
+#### `nex auth delete`
+
+Remove a credential from the store. Does not touch the OS keyring, so a copy kept
+there before migrating remains.
+
+| Flag | Short | Type | Required | Default | Description |
+|------|-------|------|----------|---------|-------------|
+| `<alias>` | | arg | no | — | Alias to remove |
+| `--all` | | boolean | no | `false` | Remove every stored credential |
+
+```bash
+nex auth delete old-alias
+nex auth delete --all
 ```
 
 ---

--- a/docs/ai-agents/README.md
+++ b/docs/ai-agents/README.md
@@ -65,11 +65,31 @@ Before your agent can use `nex` commands, ensure:
 
 2. **Auth aliases are configured** for your ServiceNow instances
    ```bash
-   now-sdk auth add --alias dev --host https://dev12345.service-now.com
-   now-sdk auth add --alias prod --host https://prod12345.service-now.com
+   now-sdk auth --add dev12345.service-now.com --alias dev --type oauth
+   now-sdk auth --add prod12345.service-now.com --alias prod --type oauth
    ```
 
-3. **Node.js 22+** is available in the environment
+3. **Node.js 26+** is available in the environment
+
+4. **For headless agents**, `@sonisoft/sn-credstore` is installed and the
+   credentials imported — otherwise the agent cannot read them at all
+   ```bash
+   npm install -g @sonisoft/sn-credstore
+
+   # Run this from a desktop session on a TTY; the keyring will prompt to unlock.
+   sn-credstore import --from keyring
+   ```
+
+   Then either add `--cred-store` to each command, or set it once:
+   ```bash
+   export SN_CRED_STORE_ENABLE=1
+   ```
+
+   This matters because the failure without it is silent and misleading. The OS
+   keyring cannot be unlocked from a non-interactive session even as the same
+   user, and the SDK reports it as `Could not find stored credentials for alias:
+   dev` — which looks like a missing alias, so the obvious fix does not help.
+   `nex auth doctor` tells the two apart.
 
 ## Customization
 

--- a/src/commands/auth/doctor.ts
+++ b/src/commands/auth/doctor.ts
@@ -52,11 +52,23 @@ static flags = {...credStoreFlag}
 
     if (this.jsonEnabled()) return report
 
-    this.log(`shim active   : ${shimActive ? 'yes' : 'NO'}`)
+    this.log(`shim active   : ${shimActive ? 'yes' : 'no'}`)
     if (!shimActive) {
+      // "no" is the DEFAULT, not a fault — the shim is opt-in. The previous
+      // wording ("NO", plus a hint to check SN_CRED_STORE_DISABLE) read as though
+      // something were broken, and pointed at the one variable that is almost
+      // never the reason. Say what to do instead.
       this.log('')
-      this.log('  The SDK is reading the OS keyring, which non-interactive sessions cannot unlock.')
-      this.log('  If this is unexpected, check that SN_CRED_STORE_DISABLE is unset.')
+      this.log('  The SDK is reading the OS keyring. That is the default and works fine with an')
+      this.log('  interactive desktop session.')
+      this.log('')
+      this.log('  In a headless session — SSH, systemd, CI, an agent — the keyring cannot be')
+      this.log('  unlocked and will report no credentials whatever is stored. To use the store')
+      this.log('  listed below instead, pass --cred-store or set SN_CRED_STORE_ENABLE=1.')
+      if (process.env.SN_CRED_STORE_DISABLE) {
+        this.log('')
+        this.log('  NOTE: SN_CRED_STORE_DISABLE is set, which overrides both of those.')
+      }
     }
 
     this.log(`store         : ${config.store}`)


### PR DESCRIPTION
`docs/ai-agents/` is the guidance that gets loaded into agent configs — and it's the audience that most needs the credential store, since an autonomous agent is the canonical non-interactive session. It said nothing about it.

Added in four places: the **Authentication** section, the **Global Flags** table, the **Quick Reference**, and a full **Auth** topic in the command reference.

The emphasis is on the failure being *misleading* rather than on the feature existing. An agent that hits:

```
Could not find stored credentials for alias: dev
```

will reasonably conclude the alias is missing and try to re-add it — which cannot work, and burns turns. The doc now quotes that exact string and says what it actually means.

## Two pre-existing errors that would have broken any agent following the docs

**The setup command doesn't exist.** Step 2 of the prerequisites said:

```bash
now-sdk auth add --alias dev --host https://dev12345.service-now.com   # ✗ not a thing
```

There is no `add` subcommand and no `--host` flag. Verified against `now-sdk auth --help`; the real syntax is:

```bash
now-sdk auth --add dev12345.service-now.com --alias dev --type oauth
```

An agent following setup failed on the first step.

**"Node.js 22+" was stale** — `package.json` requires `>=26.0.0`.

## On the command counts

Dropped `69 commands across 18 topics` rather than correcting it. The real figures are **71 across 21**, so the doc was wrong in both directions even before these four commands were added — replacing one hard number with another just resets a clock that's already proven it rots. I verified separately that no actual command is missing from the reference.

## `nex auth doctor` reworded

It printed `shim active : NO` followed by a hint to check `SN_CRED_STORE_DISABLE` — which reads as a fault and points at the variable that's almost never the reason. The shim being off is the **default** now that it's opt-in. It now explains that the keyring is fine interactively, says what to pass for headless use, and mentions `SN_CRED_STORE_DISABLE` only when that variable is actually set.

## Verification

Every command and error string quoted in the docs was executed to confirm it behaves as written — `auth doctor` in all three states (default, shim on, override set), `auth list --json`, and the `Could not find stored credentials` text.

1092/1092 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MggifJUgccB2gu3NsPbtUV