### PR TITLE
fix(cli): refuse to run when a secret is passed in argv (NEX-54)

### DIFF
--- a/bin/argv-guard.js
+++ b/bin/argv-guard.js
@@ -1,0 +1,25 @@
+/* eslint-disable n/no-process-exit, unicorn/no-process-exit -- this runs before
+   oclif exists, so there is no error handler to throw into; an uncaught rejection
+   here would print a stack trace instead of the remediation. */
+
+/**
+ * Side-effecting half of the argv secret check.
+ *
+ * Split from bin/argv-secrets.js so the detection logic can be imported and
+ * tested without the import itself terminating the test process.
+ *
+ * Imported for its side effect by bin/run.js and bin/dev.js, before
+ * credstore-boot.js — a secret in argv should be refused before anything reads,
+ * stores, or logs a credential.
+ */
+
+import {findSecretArgument, secretArgumentMessage} from './argv-secrets.js'
+
+// slice(2): skip the node binary and the script path, so a secret-shaped
+// filename in the invocation cannot trip the check.
+const found = findSecretArgument(process.argv.slice(2))
+
+if (found) {
+    process.stderr.write(secretArgumentMessage(found))
+    process.exit(2)
+}

--- a/bin/argv-secrets.js
+++ b/bin/argv-secrets.js
@@ -1,0 +1,103 @@
+/**
+ * Refuse to run when a secret was passed as a command-line argument.
+ *
+ * Anything in argv is already exposed by the time this runs: the shell has
+ * written it to history, and it is visible to every process on the host via
+ * `ps auxww` for as long as this one lives. Neither can be undone from here.
+ *
+ * So this is not really prevention — it is detection plus an honest message. The
+ * user needs to know the value leaked and should be rotated, which is strictly
+ * more useful than oclif's "Nonexistent flag: --password". Refusing to run also
+ * makes the habit fail fast rather than working quietly until someone greps a
+ * shell history.
+ *
+ * None of these flags exist on any `nex` command today, so nothing legitimate is
+ * blocked. The check is deliberately conservative about that: it matches on flag
+ * NAME only, never on the shape of a value, because `nex exec` takes arbitrary
+ * scripts and `--query`, `--filter`, `--data`, `--payload` and `--spec` all take
+ * arbitrary text that can look like anything.
+ *
+ * Kept as plain JS in bin/ for the same reason as credstore-boot.js: it runs
+ * before oclif and before any build output is required.
+ */
+
+/**
+ * Long flags whose value would be a credential.
+ *
+ * Short flags are deliberately excluded — `-p` and `-t` are too easily something
+ * else, and a false positive here blocks legitimate work.
+ */
+const SECRET_FLAGS = new Set([
+    '--password',
+    '--passwd',
+    '--pass',
+    '--secret',
+    '--client-secret',
+    '--clientsecret',
+    '--token',
+    '--access-token',
+    '--refresh-token',
+    '--id-token',
+    '--auth-token',
+    '--user-token',
+    '--session-token',
+    '--api-key',
+    '--apikey',
+    '--credential',
+    '--credentials',
+])
+
+/**
+ * Returns details of the first secret-bearing argument, or null.
+ *
+ * Only reports when a value is actually present. `--password` with nothing after
+ * it, or followed by another flag, carries no secret — oclif will reject it as a
+ * missing value, which is not this file's problem.
+ *
+ * @param {string[]} argv
+ * @returns {{flag: string, form: 'inline' | 'separate'} | null}
+ */
+export function findSecretArgument(argv) {
+    if (!Array.isArray(argv)) return null
+
+    for (const [index, arg] of argv.entries()) {
+        if (typeof arg !== 'string' || !arg.startsWith('--')) continue
+
+        const equals = arg.indexOf('=')
+        const name = (equals === -1 ? arg : arg.slice(0, equals)).toLowerCase()
+        if (!SECRET_FLAGS.has(name)) continue
+
+        if (equals !== -1) {
+            // `--password=` with nothing after it carries no value.
+            if (arg.length > equals + 1) return {flag: name, form: 'inline'}
+            continue
+        }
+
+        const next = argv[index + 1]
+        if (next !== undefined && !next.startsWith('-')) return {flag: name, form: 'separate'}
+    }
+
+    return null
+}
+
+/**
+ * Human-facing message for a detected secret argument.
+ *
+ * Leads with the exposure rather than the refusal, because the exposure is the
+ * part the user has to act on and cannot undo.
+ *
+ * @param {{flag: string}} found
+ * @returns {string}
+ */
+export function secretArgumentMessage(found) {
+    return (
+        `nex: refusing to run — a secret was passed on the command line (${found.flag}).\n` +
+        `\nThat value is already in your shell history and was visible in the process\n` +
+        `list while this command started. Treat it as compromised and rotate it.\n` +
+        `\nRemediation: store credentials once instead of passing them per command.\n` +
+        `  now-sdk auth --add <instance>     # add a credential\n` +
+        `  nex auth list                     # see what is stored\n` +
+        `  nex --auth <alias> ...            # select one per command\n` +
+        `\nFor non-interactive use, set the value in the environment rather than argv.\n`
+    )
+}

--- a/bin/dev.js
+++ b/bin/dev.js
@@ -1,8 +1,12 @@
 #!/usr/bin/env -S node --loader ts-node/esm --disable-warning=ExperimentalWarning
 
-// FIRST, deliberately: redirect SDK credential storage off the OS keyring
-// before anything can read credentials. See bin/credstore-boot.js.
+// FIRST, deliberately: refuse to run if a secret was passed in argv, before
+// anything can read, store, or log it. See bin/argv-guard.js.
 // eslint-disable-next-line n/shebang
+import './argv-guard.js'
+
+// THEN: redirect SDK credential storage off the OS keyring before anything can
+// read credentials. See bin/credstore-boot.js.
 import './credstore-boot.js'
 
 import {execute} from '@oclif/core'

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 
-// FIRST, deliberately: redirect SDK credential storage off the OS keyring
-// before anything can read credentials. See bin/credstore-boot.js.
+// FIRST, deliberately: refuse to run if a secret was passed in argv, before
+// anything can read, store, or log it. See bin/argv-guard.js.
+import './argv-guard.js'
+
+// THEN: redirect SDK credential storage off the OS keyring before anything can
+// read credentials. See bin/credstore-boot.js.
 import './credstore-boot.js'
 
 import {execute} from '@oclif/core'

--- a/test/common/argv-secrets-unit.test.ts
+++ b/test/common/argv-secrets-unit.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the argv secret check (NEX-54).
+ *
+ * The risk profile here is lopsided: a missed detection costs a warning nobody
+ * saw, but a false positive blocks legitimate work outright. `nex exec` takes
+ * arbitrary scripts and --query/--filter/--data/--payload/--spec all take
+ * arbitrary text, so most of these tests are about NOT firing.
+ */
+
+import {describe, expect, it} from '@jest/globals'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error -- plain JS module in bin/, deliberately not part of the TS build
+import {findSecretArgument, secretArgumentMessage} from '../../bin/argv-secrets.js'
+
+describe('findSecretArgument', () => {
+    describe('detects a secret carrying a value', () => {
+        it.each([
+            ['--password', 'hunter2'],
+            ['--client-secret', 'abc123'],
+            ['--token', 'eyJhbGciOi'],
+            ['--access-token', 'tok'],
+            ['--refresh-token', 'tok'],
+            ['--api-key', 'key'],
+            ['--credential', 'c'],
+        ])('separated form: %s', (flag, value) => {
+            const found = findSecretArgument(['query', flag, value])
+            expect(found).not.toBeNull()
+            expect(found.flag).toBe(flag)
+            expect(found.form).toBe('separate')
+        })
+
+        it.each([
+            '--password=hunter2',
+            '--client-secret=abc123',
+            '--token=eyJhbGciOi',
+            '--api-key=key',
+        ])('inline form: %s', (arg) => {
+            const found = findSecretArgument(['query', arg])
+            expect(found).not.toBeNull()
+            expect(found.form).toBe('inline')
+        })
+
+        it('is case-insensitive on the flag name', () => {
+            expect(findSecretArgument(['--PASSWORD', 'x'])).not.toBeNull()
+        })
+
+        it('finds a secret anywhere in the argument list', () => {
+            expect(findSecretArgument(['query', '--table', 'incident', '--token', 't'])).not.toBeNull()
+        })
+    })
+
+    describe('does not fire without an actual value', () => {
+        it('ignores a trailing flag with nothing after it', () => {
+            expect(findSecretArgument(['query', '--password'])).toBeNull()
+        })
+
+        it('ignores a flag followed by another flag', () => {
+            expect(findSecretArgument(['--password', '--json'])).toBeNull()
+        })
+
+        it('ignores an empty inline value', () => {
+            expect(findSecretArgument(['--password='])).toBeNull()
+        })
+    })
+
+    describe('does not fire on legitimate arguments', () => {
+        it('leaves ordinary commands alone', () => {
+            expect(findSecretArgument(['query', '--table', 'incident', '--limit', '10'])).toBeNull()
+        })
+
+        it('leaves an encoded query alone even when it mentions a password field', () => {
+            expect(
+                findSecretArgument(['query', '--query', 'user_password!=NULL^active=true']),
+            ).toBeNull()
+        })
+
+        it('leaves an exec script alone even when it contains the word password', () => {
+            expect(
+                findSecretArgument(['exec', 'global', '--params', '{"password":"in-a-payload"}']),
+            ).toBeNull()
+        })
+
+        it('leaves a log filter alone', () => {
+            expect(findSecretArgument(['log', '--filter', 'message CONTAINS token'])).toBeNull()
+        })
+
+        it('leaves --data and --payload alone, which carry arbitrary JSON', () => {
+            expect(findSecretArgument(['bulk', 'update', '--data', '{"secret_field":"x"}'])).toBeNull()
+            expect(findSecretArgument(['flow', 'message', '--payload', '{"token":"x"}'])).toBeNull()
+        })
+
+        it('does not match a short flag, which is too easily something else', () => {
+            expect(findSecretArgument(['-p', 'value'])).toBeNull()
+        })
+
+        it('does not match a partial or unrelated long flag', () => {
+            expect(findSecretArgument(['--password-file', 'p'])).toBeNull()
+            expect(findSecretArgument(['--tokenize', 'x'])).toBeNull()
+        })
+    })
+
+    describe('input handling', () => {
+        it('returns null for an empty or non-array argv', () => {
+            expect(findSecretArgument([])).toBeNull()
+            expect(findSecretArgument(undefined)).toBeNull()
+            expect(findSecretArgument(null)).toBeNull()
+        })
+
+        it('skips non-string entries rather than throwing', () => {
+            expect(() => findSecretArgument(['query', 42, null, '--json'])).not.toThrow()
+        })
+    })
+})
+
+describe('secretArgumentMessage', () => {
+    it('leads with the exposure, since that is the part the user must act on', () => {
+        const message = secretArgumentMessage({flag: '--password'})
+        expect(message).toContain('shell history')
+        expect(message).toContain('process')
+        expect(message).toMatch(/rotate/i)
+    })
+
+    it('names the offending flag and a concrete alternative', () => {
+        const message = secretArgumentMessage({flag: '--client-secret'})
+        expect(message).toContain('--client-secret')
+        expect(message).toContain('nex auth list')
+        expect(message).toMatch(/Remediation:/)
+    })
+})


### PR DESCRIPTION
Closes NEX-54. Third of four in epic NEX-49 (credential and secret safety hardening). Independent of the core PRs — different repo, no shared history.

## Framing, because it changed during implementation

Anything in argv is **already exposed** by the time `nex` starts: the shell has written it to history, and it is visible to every process on the host via `ps auxww` for as long as this one lives. Neither can be undone from inside the process.

So this is not prevention. It is detection plus an honest message — the user needs to know the value leaked and should be **rotated**, which is considerably more useful than oclif's `Nonexistent flag: --password`. Refusing to run also makes the habit fail fast rather than working quietly until someone greps a shell history.

## Placement

Screened in `bin/`, before oclif and before `credstore-boot`, for the same reason `credstore-boot` reads argv directly: the check has to happen before anything reads, stores, or logs a credential, and that is well before oclif has parsed a flag.

Detection is split from the exit (`argv-secrets.js` / `argv-guard.js`) so the logic can be imported by a test without terminating the test process.

## The risk here is false positives, not misses

A missed detection costs a warning nobody saw. A false positive blocks legitimate work outright. So matching is on **flag name only, never on the shape of a value** — `nex exec` takes arbitrary scripts, and `--query`, `--filter`, `--data`, `--payload` and `--spec` all take arbitrary text that can contain anything.

Also excluded: short flags (`-p` is too easily something else), and a flag with no value following it (oclif's problem, and no secret is present).

Verified end to end that all of these pass through untouched:

```
nex query --table incident --query 'user_password!=NULL'
nex exec global --params '{"password":"x"}'
nex log --filter 'message CONTAINS token'
```

## Scope note

**None of these flags exist on any command today**, so nothing legitimate is blocked right now. Two reasons it is still worth having: the diagnostic is far better than "unknown flag", and adding such a flag later cannot quietly reintroduce the exposure.

## Verification

- 27 new unit tests; 547 tests across 24 suites pass.
- `tsc --noEmit` clean. eslint unchanged at 14 errors — identical to `main`, and this touches only `bin/` and `test/`, which eslint does not scan.
- Confirmed exit code 2 on a real invocation, and that `--version` still reaches oclif normally.
