### PR TITLE
ci+docs: publish on release via Trusted Publisher, hydrate agent docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,27 @@
 name: Publish to npm
 
 on:
-  # Manual trigger only — use the "Run workflow" button in GitHub Actions.
-  # Requires the "npm" environment approval (configured in repo settings).
+  # Publish automatically when semantic-release cuts a GitHub release.
+  #
+  # This only fires because release.yml runs semantic-release with RELEASE_TOKEN
+  # rather than the default GITHUB_TOKEN: GitHub deliberately suppresses events
+  # raised by GITHUB_TOKEN so a workflow cannot trigger further workflows. If
+  # RELEASE_TOKEN is ever removed, releases keep working and this trigger SILENTLY
+  # stops firing — the failure mode is a package that quietly stops reaching npm.
+  #
+  # Chosen over `workflow_run` on release.yml because semantic-release only cuts a
+  # release when there is something to release, so a no-op merge does not publish.
+  # github.ref is the new tag, whose package.json holds exactly the released
+  # version, and the "already exists on npm" check below keeps it idempotent.
+  release:
+    types: [published]
+
+  # Retained for backfill, dry runs, and republishing a specific ref — use the
+  # "Run workflow" button in GitHub Actions.
+  #
+  # Note `inputs` is empty on a release trigger: dry-run is then not `true` so the
+  # real publish runs, and the empty tag falls through to the version-based rule
+  # below (prerelease -> next, otherwise latest).
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,15 +92,17 @@ jobs:
 
       - name: Publish (dry run)
         if: inputs.dry-run == true && steps.dist-tag.outputs.skip != 'true'
+        # No NODE_AUTH_TOKEN: this package publishes via a Trusted Publisher
+        # (OIDC), which npm derives from the id-token permission above. npmjs is
+        # phasing token-based publishing out — if publishing breaks, fix the
+        # trusted publisher config on npmjs rather than reintroducing a secret.
         run: npm publish --access public --tag "${{ steps.dist-tag.outputs.tag }}" --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
         if: inputs.dry-run != true && steps.dist-tag.outputs.skip != 'true'
+        # See the dry-run step above: Trusted Publisher (OIDC), no token. The
+        # same OIDC identity is what makes --provenance possible.
         run: npm publish --access public --tag "${{ steps.dist-tag.outputs.tag }}" --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Summary
         if: inputs.dry-run != true && steps.dist-tag.outputs.skip != 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# AGENTS.md
+
+Operating rules for automated agents working in this repository.
+
+For architecture, layout and build commands, read [`CLAUDE.md`](./CLAUDE.md).
+This file is only about the things that will bite you *here* and not elsewhere.
+
+---
+
+## What this repository is
+
+A CLI that developers point at real ServiceNow instances, authenticated with real
+credentials. Commands here delete records, install applications, execute
+arbitrary server-side script, and switch update sets.
+
+The blast radius of a wrong instance is production, not a test fixture.
+
+---
+
+## Hard rules
+
+### 1. Never run a mutating command against a real instance
+
+`nex` resolves a credential and runs. There is no dry-run at the CLI level except
+where a command explicitly offers `--confirm` (`bulk update`, `bulk delete`).
+
+Anything under `app`, `store`, `update-set`, `scope`, `task`, `xml import`,
+`batch`, `bulk`, `exec`, `flow` and `script-sync push` **writes**. Do not invoke
+them to "check something works". Read the command source instead, or use
+`--help`.
+
+`nex exec` is the sharpest: it runs arbitrary server-side JavaScript with the
+caller's rights.
+
+### 2. Never mutate the real credential store
+
+`nex auth use|delete` and `--cred-store` operate on live credentials shared with
+the ServiceNow SDK. Redirect first:
+
+```bash
+export SN_CRED_STORE=file
+export SN_CRED_STORE_PATH="$(mktemp -d)/credentials.json"
+```
+
+Then **verify the redirect took effect** rather than assuming it did — ask the
+code where it actually resolved (`nex auth doctor --json` reports the path). The
+sibling `sn-credstore` repo records an incident where a mock silently failed to
+apply under jest ESM and a real store was wiped.
+
+### 3. `bin/` runs before oclif and before `dist/` exists
+
+Everything in `bin/` is plain JavaScript for that reason. It cannot be
+TypeScript, cannot import from `dist/`, and cannot rely on anything oclif has
+parsed — the credential shim has to install before `AuthenticatedCommand.init()`
+resolves a credential, which is before flags exist.
+
+That is why `credstore-boot.js` and `argv-guard.js` read `process.argv`
+directly. Preserve the import order in `run.js` / `dev.js`: argv guard first,
+credential shim second, oclif last.
+
+### 4. Never widen the argv secret check to match values
+
+`bin/argv-secrets.js` matches on **flag name only**. That is deliberate and
+load-bearing: `nex exec` takes arbitrary scripts, and `--query`, `--filter`,
+`--data`, `--payload` and `--spec` all take arbitrary text that can contain
+anything a secret-shaped regex would match.
+
+A missed detection costs a warning nobody saw. A false positive blocks legitimate
+work outright. Bias hard toward the former.
+
+Note the guard cannot *prevent* the leak — by the time the process starts, the
+value is in shell history and `ps`. Its job is to say so and tell the user to
+rotate.
+
+### 5. `eslint` only sees `src/`
+
+`npm run lint` is `eslint src/`. `bin/` and `test/` are **not linted at all**, so
+a clean lint run says nothing about them. Type-check separately with
+`npx tsc --noEmit` if you touched anything typed.
+
+### 6. Test placement decides whether a test runs
+
+The unit/integration split is by path pattern, not directory intent:
+
+- `test:unit` → `(services|common)`
+- `test:integration` → `commands`
+
+A test in `test/helpers/` or `test/util/` matches **neither** and runs in no CI
+job. Put unit tests for `bin/` code under `test/common/`.
+
+---
+
+## Conventions that are easy to get wrong
+
+- 2-space indent, single quotes, **no semicolons**. The sibling `sn-credstore`
+  repo uses 4-space and semicolons — do not copy style across repos.
+- Output belongs in a display service under `src/services/`, not inline in a
+  command.
+- Never log `credential` or `snSettings`. `--log-level debug` would write the
+  password to the terminal and to CI logs; there is a comment at
+  `src/common/authenticated-command.ts` saying exactly this.
+- Errors from `sn-credstore` carry a `remediation` field. Surface it — that is
+  the whole point of the taxonomy. Duck-type it (`(e as {remediation?: string})`)
+  rather than `instanceof`, which is unreliable across its dual ESM/CJS build.
+
+## Before you open a PR
+
+```bash
+npm run build
+npm run lint          # src/ only
+npm run test:unit
+```
+
+Integration tests need a real instance and are not run in CI. Do not run them
+casually — see rule 1.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# now-sdk-ext-cli
+
+`nex` — a CLI extending the ServiceNow SDK, built on `@sonisoft/now-sdk-ext-core`.
+
+## Project Overview
+
+An oclif v4 CLI exposing core's manager classes as commands: querying, schema
+discovery, background script execution, flows, ATF, update sets, app install,
+code search, log tailing and more. Core does the ServiceNow work; this repo is
+argument parsing, output formatting, and the interactive surfaces.
+
+## Architecture
+
+- **`bin/`** — plain JS, ESM. Runs **before** oclif and before any build output
+  exists, so nothing here may be TypeScript or import from `dist/`.
+  - `argv-guard.js` / `argv-secrets.js` — refuse to run if a secret was passed in argv
+  - `credstore-boot.js` — opt into headless-safe credential storage
+- **`src/commands/`** — one directory per oclif topic (20 topics). Command
+  discovery is by file path, so the directory layout *is* the command tree.
+- **`src/common/`** — `AuthenticatedCommand` (the base every non-`auth` command
+  extends, supplying `--auth`, `--cred-store`, `--log-level`), plus
+  `scope-autocomplete.ts`.
+- **`src/services/`** — display services. Roughly 19 of them, all hand-rolled
+  padded text tables. This is where output formatting lives, not in commands.
+
+## Sibling Projects
+
+- **Core**: `../now-sdk-ext-core` (`@sonisoft/now-sdk-ext-core`) — all ServiceNow
+  behaviour. Add capability there, expose it here.
+- **MCP server**: `../now-sdk-ext-mcp` — the same core surfaced to AI agents.
+- **Credential store**: `../sn-credstore` — headless-safe credential storage.
+
+## Build & Run
+
+```bash
+npm run build        # clean + tsc + tsc-alias
+npm run lint         # eslint src/  (NOTE: src only — see AGENTS.md)
+./bin/dev.js <cmd>   # run from source via ts-node
+./bin/run.js <cmd>   # run from dist/
+```
+
+## Testing
+
+```bash
+npm run test:unit         # services + common only
+npm run test:integration  # commands/ — hits a real instance
+```
+
+The split is by **path pattern**, not by directory convention:
+`test:unit` matches `(services|common)`, `test:integration` matches `commands`.
+A test placed outside those paths runs in neither.
+
+## Key Patterns
+
+- Every non-`auth` command extends `AuthenticatedCommand`, which resolves the
+  credential and constructs a `ServiceNowInstance`. `auth` commands talk to
+  `@sonisoft/sn-credstore` directly instead.
+- `static enableJsonFlag = true` — most commands support `--json`.
+- Output goes through a display service; commands should not build tables inline.
+- `nex exec` is the only interactive surface (a REPL). `nex log` is a long-running
+  tail with a SIGINT handler.
+
+## Conventions
+
+- ES Modules, TypeScript, target ES2022
+- 2-space indent, single quotes, no semicolons (differs from `sn-credstore`,
+  which uses 4-space)
+- Conventional commits (angular preset); semantic-release publishes on merge
+
+## Releasing & Publishing
+
+**Publishing to npm uses a Trusted Publisher (OIDC), not an auth token.** npmjs is
+phasing token-based publishing out, so nothing here should reintroduce one.
+
+- The workflow needs `permissions: id-token: write`. Without it npm cannot mint
+  the OIDC credential, and the failure reads like a missing token — which is the
+  wrong thing to go looking for.
+- The package must be registered as a trusted publisher on npmjs, bound to this
+  repository and workflow file. Renaming `publish.yml` breaks that binding.
+- `--provenance` works off the same OIDC identity.
+- Do NOT add an `NPM_TOKEN` back. If publishing fails, the fix is in the trusted
+  publisher configuration on npmjs, not a new secret.
+
+The release chain:
+
+1. Merge to `main` → `release.yml` runs `semantic-release` (conventional commits,
+   angular preset). It bumps, tags, and cuts a GitHub release. `npmPublish` is
+   `false` — semantic-release never publishes.
+2. That GitHub release fires `publish.yml`, which builds and publishes.
+
+Step 2 fires **only** because `release.yml` runs semantic-release with
+`RELEASE_TOKEN` rather than the default `GITHUB_TOKEN`. GitHub suppresses events
+raised by `GITHUB_TOKEN` so a workflow cannot trigger further workflows. Since
+`release.yml` falls back (`secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN`),
+removing that secret leaves releases working while publishing silently stops.
+
+`publish.yml` also accepts `workflow_dispatch` for backfill, dry runs, or
+republishing a ref. It skips when the version already exists on npm, so re-running
+is a no-op rather than an error.


### PR DESCRIPTION
Releases and publishes had drifted apart. semantic-release cuts a GitHub release on every merge to `main`, but `publish.yml` was `workflow_dispatch` only — so a package reached npm solely when someone remembered to press the button.

**Core 5.2.0 is the live example:** released, tagged, and *not on npm*, while two sibling packages depend on it. So the credential-safety fixes that merged today aren't reaching any consumer.

## Why `release: published` and not `workflow_run`

semantic-release only cuts a release when there's something to release, so a no-op merge doesn't publish. `github.ref` is then the new tag, whose `package.json` holds exactly the released version — no version-guessing.

## The detail that makes it work (and could silently break it)

This fires **only** because `release.yml` runs semantic-release with `RELEASE_TOKEN` rather than the default `GITHUB_TOKEN`. GitHub deliberately suppresses events raised by `GITHUB_TOKEN` so a workflow can't trigger further workflows — had it fallen back, this trigger would never have fired and the automation would have looked broken for no visible reason.

`release.yml` uses `secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN`, so **removing that secret leaves releases working while publishing silently stops**. That failure mode is called out in a comment at the trigger, because it's invisible otherwise.

## What doesn't change

`workflow_dispatch` is kept for backfill, dry runs, and republishing a specific ref.

On a release trigger `inputs` is empty, which the existing conditionals already handle correctly:
- `inputs.dry-run != true` → real publish runs
- `inputs.dry-run == true` → dry-run step skipped
- empty `inputs.tag` → falls through to the version-based rule (prerelease → `next`, else `latest`)

The existing "already exists on npm" check keeps it idempotent — a re-run, or a manual publish of a version already released, is a no-op rather than an error.

The `npm` environment is retained. It scopes `NPM_TOKEN` rather than gating: it currently has no protection rules and no required reviewers, so this is genuinely automatic with no approval prompt. Adding reviewers there later would turn it back into a gate without touching this file.
