### PR TITLE
feat(cli): add --log-file and --log-dir, and stop logging to files by default (NEX-3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,11 @@ job. Put unit tests for `bin/` code under `test/common/`.
 - Never log `credential` or `snSettings`. `--log-level debug` would write the
   password to the terminal and to CI logs; there is a comment at
   `src/common/authenticated-command.ts` saying exactly this.
+- **Do not write files unless asked.** `nex` used to drop `./logs/*.log` into
+  whatever directory it ran from, because core's logger had hard-coded relative
+  paths (NEX-3). File logging is now opt-in via `--log-file` / `--log-dir`, and
+  `test/common/logging-e2e.test.ts` spawns the real binary to prove it — a flag
+  test alone would pass even if `configureLogging()` were never called.
 - Errors from `sn-credstore` carry a `remediation` field. Surface it — that is
   the whole point of the taxonomy. Duck-type it (`(e as {remediation?: string})`)
   rather than `instanceof`, which is unreliable across its dual ESM/CJS build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ argument parsing, output formatting, and the interactive surfaces.
 - **`src/commands/`** — one directory per oclif topic (20 topics). Command
   discovery is by file path, so the directory layout *is* the command tree.
 - **`src/common/`** — `AuthenticatedCommand` (the base every non-`auth` command
-  extends, supplying `--auth`, `--cred-store`, `--log-level`), plus
+  extends, supplying `--auth`, `--cred-store`, `--log-level`, `--log-file`,
+  `--log-dir`), plus
   `scope-autocomplete.ts`.
 - **`src/services/`** — display services. Roughly 19 of them, all hand-rolled
   padded text tables. This is where output formatting lives, not in commands.
@@ -56,6 +57,14 @@ A test placed outside those paths runs in neither.
   credential and constructs a `ServiceNowInstance`. `auth` commands talk to
   `@sonisoft/sn-credstore` directly instead.
 - `static enableJsonFlag = true` — most commands support `--json`.
+- **Logging is configured once, in `AuthenticatedCommand.init()`, before any logger
+  is created.** Core builds one logger for the whole process, so `configureLogging()`
+  is the only thing that reaches the ~43 loggers inside core; passing a level to an
+  individual `Logger` has never worked. File logging is OFF unless `--log-file` or
+  `--log-dir` is given — `nex` must not write into the directory it was run from.
+- `flushLogs()` is awaited in both `catch()` and `finally()`. Winston buffers, and
+  `super.catch()` can terminate the process before `finally()` runs, which loses the
+  failure line — the one worth keeping.
 - Output goes through a display service; commands should not build tables inline.
 - `nex exec` is the only interactive surface (a REPL). `nex log` is a long-running
   tail with a SIGINT handler.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@servicenow/sdk-cli": "4.9.2",
         "@servicenow/sdk-cli-core": "3.0.3",
         "@servicenow/sdk-core": "4.9.2",
-        "@sonisoft/now-sdk-ext-core": "^5.0.1",
+        "@sonisoft/now-sdk-ext-core": "^6.0.0",
         "@sonisoft/sn-credstore": "^1.0.0",
         "@ts-morph/common": "^0.24.0",
         "chalk": "^4.1.2",
@@ -11820,9 +11820,9 @@
       }
     },
     "node_modules/@sonisoft/now-sdk-ext-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@sonisoft/now-sdk-ext-core/-/now-sdk-ext-core-5.0.1.tgz",
-      "integrity": "sha512-CJjt0sYGrrdXp+ycCsUPbimliug9M0cDv6aim35mhBkJJjyHyvjYXCNDVaz3tXx56AuGaM/+EuPVX4pM4SqDLA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sonisoft/now-sdk-ext-core/-/now-sdk-ext-core-6.0.0.tgz",
+      "integrity": "sha512-5U4l9/L20uwjGR1MQnf8WP5Td5t/hEk4r+tt2sr98f7ooNF5bam3J2POGhC1aPJWzdfNsToHWWg49kAUhx4fGg==",
       "license": "MIT",
       "dependencies": {
         "@servicenow/glide": "^27.0.5",
@@ -11853,6 +11853,9 @@
       },
       "engines": {
         "node": ">=26.0.0"
+      },
+      "optionalDependencies": {
+        "@sonisoft/sn-credstore": "^1.0.0"
       }
     },
     "node_modules/@sonisoft/now-sdk-ext-core/node_modules/fast-xml-parser": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@servicenow/sdk-cli": "4.9.2",
     "@servicenow/sdk-cli-core": "3.0.3",
     "@servicenow/sdk-core": "4.9.2",
-    "@sonisoft/now-sdk-ext-core": "^5.0.1",
+    "@sonisoft/now-sdk-ext-core": "^6.0.0",
     "@sonisoft/sn-credstore": "^1.0.0",
     "@ts-morph/common": "^0.24.0",
     "chalk": "^4.1.2",

--- a/src/common/authenticated-command.ts
+++ b/src/common/authenticated-command.ts
@@ -2,7 +2,7 @@
 
 import { Command, Flags, Interfaces } from '@oclif/core'
 import { getCredentials } from "@servicenow/sdk-cli/dist/auth/index.js";
-import { Logger, ServiceNowInstance, ServiceNowSettingsInstance } from '@sonisoft/now-sdk-ext-core';
+import { configureLogging, flushLogs, Logger, ServiceNowInstance, ServiceNowSettingsInstance } from '@sonisoft/now-sdk-ext-core';
 
 import { LogFactory } from '../util/log-factory.js';
 
@@ -25,12 +25,27 @@ export abstract class AuthenticatedCommand<T extends typeof Command> extends Com
       helpGroup: 'GLOBAL',
       required: false,
     }),
+    'log-dir': Flags.string({
+      description: 'Directory to write log files to. Implies --log-file.',
+      helpGroup: 'GLOBAL',
+      required: false,
+    }),
+    // Logging to a file is opt-in. It used to be unconditional, writing
+    // ./logs/*.log into whatever directory nex happened to be run from — including
+    // CI checkouts — with no way to turn it off. See NEX-3.
+    'log-file': Flags.boolean({
+      description: 'Write logs to a file. Defaults to $XDG_STATE_HOME/now-sdk-ext/logs ' +
+        '(~/.local/state/now-sdk-ext/logs). Off by default; without this, nex logs ' +
+        'warnings and errors to stderr only.',
+      helpGroup: 'GLOBAL',
+      required: false,
+    }),
     'log-level': Flags.option({
       default: 'info',
       helpGroup: 'GLOBAL',
       options: ['debug', 'warn', 'error', 'info', 'trace'] as const,
       summary: 'Specify level for logging.',
-      
+
     })(),
   }
 // add the --json flag
@@ -56,11 +71,19 @@ protected instance!:ServiceNowInstance;
     // (reading 'error')", hiding the actual usage error behind a TypeError.
     this.authLogger?.error("Globally caught exception occurred.", err);
 
+    // Flush HERE, not only in finally(). super.catch() routes into oclif's error
+    // handler, which can terminate the process — so finally() is not guaranteed to
+    // run, and the record that just got logged is precisely the one worth keeping.
+    // Winston buffers, so without this the failure line is lost intermittently.
+    await flushLogs()
+
     return super.catch(err)
   }
 
   protected async finally(_: Error | undefined): Promise<any> {
-    // called after run and catch regardless of whether or not the command errored
+    // called after run and catch regardless of whether or not the command errored.
+    // Covers the success path; the failure path already flushed in catch().
+    await flushLogs()
     return super.finally(_)
   }
 
@@ -81,8 +104,25 @@ protected instance!:ServiceNowInstance;
     // value under that exact name. Reading `flags.logLevel` always yielded
     // undefined, silently pinning every command to 'info'.
     const logLevel = (this.flags['log-level'] as string | undefined) || 'info';
-    this.logger = LogFactory.createLogger(this.ctor.name, logLevel);
-    this.authLogger = LogFactory.createLogger("AuthenticatedCommand", logLevel);
+    const logDir = this.flags['log-dir'] as string | undefined;
+
+    // Configure BEFORE creating any logger. Core's loggers are field initializers on
+    // ~43 manager classes and take no arguments, so this process-wide call is the only
+    // thing that reaches them — a per-logger level never did.
+    configureLogging({
+      // --log-dir implies --log-file; requiring both would make `--log-dir ./x` alone
+      // silently produce nothing, which reads as a broken flag.
+      dir: logDir,
+      file: Boolean(this.flags['log-file']) || Boolean(logDir),
+      level: logLevel,
+      // --json puts machine-readable output on stdout. Warnings on stderr do not
+      // corrupt it, but they do land in a terminal the caller is likely piping, so
+      // stay quiet unless the level was asked for explicitly.
+      ...(this.jsonEnabled() && !this.argvHasLogLevel() ? {consoleLevel: 'error'} : {}),
+    });
+
+    this.logger = LogFactory.createLogger(this.ctor.name);
+    this.authLogger = LogFactory.createLogger("AuthenticatedCommand");
     // const wrapper:CredentialWrapper = new CredentialWrapper();
     // const credential:Creds = await (flags.auth ? wrapper.getStoredCredentialsByAlias(flags.auth) : wrapper.getStoredCredentialsByAlias( 'fluent-default'));
     // const credentialArgs = {"_": "get-credentials", auth: flags.auth || "fluent-default"};
@@ -117,6 +157,16 @@ protected instance!:ServiceNowInstance;
       credential
     }
     this.instance = new ServiceNowInstance(snSettings);
+  }
+
+  /**
+   * Whether --log-level was given on the command line rather than defaulted.
+   *
+   * oclif reports its own default as a parsed value, so `flags['log-level']` cannot
+   * distinguish "the user asked for info" from "nobody said anything".
+   */
+  private argvHasLogLevel(): boolean {
+    return this.argv.some((a) => a === '--log-level' || a.startsWith('--log-level='))
   }
 
   /**

--- a/src/util/log-factory.ts
+++ b/src/util/log-factory.ts
@@ -2,8 +2,13 @@ import { Logger } from "@sonisoft/now-sdk-ext-core";
 
 
 export class LogFactory {
-    public static createLogger(name: string, level: string = 'info'): Logger {
-        const logger = new Logger(name, level);
-        return logger;
+    /**
+     * The level is NOT a parameter any more. Core builds one logger for the process,
+     * so a per-logger level would only ever have applied to the two loggers created
+     * here and never to the ~43 inside core. Set it with `configureLogging({level})`,
+     * which AuthenticatedCommand.init does before calling this.
+     */
+    public static createLogger(name: string): Logger {
+        return new Logger(name);
     }
 }

--- a/test/common/authenticated-command-unit.test.ts
+++ b/test/common/authenticated-command-unit.test.ts
@@ -46,6 +46,37 @@ describe('AuthenticatedCommand - Unit Tests', () => {
       expect(flagNames).toContain('log-level')
       expect(flagNames).not.toContain('logLevel')
     })
+
+    // NEX-3. Core used to write ./logs/*.log unconditionally, relative to whatever
+    // directory nex was run from, with no way to turn it off. File logging is now
+    // opt-in and these are the flags that opt in.
+    it('should have log-file flag defined as a boolean in GLOBAL', () => {
+      const flag = AuthenticatedCommand.baseFlags['log-file'] as any
+      expect(flag).toBeDefined()
+      expect(flag.type).toBe('boolean')
+      expect(flag.helpGroup).toBe('GLOBAL')
+    })
+
+    it('should default log-file to off — a library must not write files uninvited', () => {
+      const flag = AuthenticatedCommand.baseFlags['log-file'] as any
+      expect(flag.default).toBeFalsy()
+    })
+
+    it('should have log-dir flag defined, and document that it implies log-file', () => {
+      const flag = AuthenticatedCommand.baseFlags['log-dir'] as any
+      expect(flag).toBeDefined()
+      expect(flag.helpGroup).toBe('GLOBAL')
+      // Without the implication, `--log-dir ./x` alone produces nothing and reads
+      // as a broken flag rather than a missing second flag.
+      expect(flag.description).toMatch(/implies --log-file/i)
+    })
+
+    it('should declare the log flags in kebab-case only', () => {
+      const flagNames = Object.keys(AuthenticatedCommand.baseFlags)
+      expect(flagNames).toEqual(expect.arrayContaining(['log-file', 'log-dir']))
+      expect(flagNames).not.toContain('logFile')
+      expect(flagNames).not.toContain('logDir')
+    })
   })
 
   describe('JSON flag support', () => {

--- a/test/common/logging-e2e.test.ts
+++ b/test/common/logging-e2e.test.ts
@@ -1,0 +1,140 @@
+/**
+ * NEX-3, end to end: nex must not write files into the directory it was run from.
+ *
+ * The bug was in core, but the guarantee is a property of the shipped CLI, and only
+ * running the real binary proves it. A unit test on flag shapes would pass even if
+ * `configureLogging` were never called — which is exactly the mistake this guards.
+ *
+ * Spawns bin/run.js in a temp cwd with an alias that cannot resolve. The command
+ * failing is fine and deliberate: the failure path is the one that logs.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import { execFile } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const REPO = process.cwd()
+const RUN = path.join(REPO, 'bin', 'run.js')
+const BUILT = fs.existsSync(path.join(REPO, 'dist', 'commands'))
+
+/** Runs nex in `cwd`; resolves with output whether it exits zero or not. */
+async function nex(
+  cwd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = {},
+): Promise<{stdout: string; stderr: string}> {
+  // Jest sets NODE_ENV=test and JEST_WORKER_ID, and oclif reads those to decide it
+  // should load TypeScript sources through ts-node instead of dist/. Inheriting them
+  // means testing something the user never runs, and it fails on a missing .js import.
+  const childEnv = {...process.env, ...env}
+  delete childEnv.NODE_ENV
+  for (const key of Object.keys(childEnv)) {
+    if (key.startsWith('JEST_')) delete childEnv[key]
+  }
+
+  try {
+    return await execFileAsync(process.execPath, [RUN, ...args], {
+      cwd,
+      env: childEnv,
+      timeout: 60_000,
+    })
+  } catch (error) {
+    const e = error as {stdout?: string; stderr?: string}
+    return {stdout: e.stdout ?? '', stderr: e.stderr ?? ''}
+  }
+}
+
+// Requires dist/. `npm run test:unit` does not build, so skip rather than fail
+// misleadingly when someone runs tests on a clean checkout.
+const maybe = BUILT ? describe : describe.skip
+
+maybe('nex logging (end to end)', () => {
+  let workdir: string
+  let stateHome: string
+
+  beforeAll(() => {
+    workdir = fs.mkdtempSync(path.join(os.tmpdir(), 'nex-e2e-'))
+    stateHome = fs.mkdtempSync(path.join(os.tmpdir(), 'nex-state-'))
+  })
+
+  afterAll(() => {
+    fs.rmSync(workdir, {force: true, recursive: true})
+    fs.rmSync(stateHome, {force: true, recursive: true})
+  })
+
+  it('creates no logs/ directory in the working directory by default', async () => {
+    await nex(workdir, ['health', 'check', '-a', 'no-such-alias-nex3'], {
+      XDG_STATE_HOME: stateHome,
+    })
+
+    // This is the whole bug: a published CLI littering the user's project.
+    expect(fs.existsSync(path.join(workdir, 'logs'))).toBe(false)
+  })
+
+  it('writes to the state directory, not the cwd, when --log-file is passed', async () => {
+    await nex(workdir, ['health', 'check', '-a', 'no-such-alias-nex3', '--log-file'], {
+      XDG_STATE_HOME: stateHome,
+    })
+
+    const logFile = path.join(stateHome, 'now-sdk-ext', 'logs', 'nex.log')
+    expect(fs.existsSync(logFile)).toBe(true)
+    expect(fs.readFileSync(logFile, 'utf8').length).toBeGreaterThan(0)
+    expect(fs.existsSync(path.join(workdir, 'logs'))).toBe(false)
+  })
+
+  it('treats --log-dir as opting in, without also needing --log-file', async () => {
+    const dir = path.join(workdir, 'chosen-logs')
+    await nex(workdir, ['health', 'check', '-a', 'no-such-alias-nex3', '--log-dir', dir], {
+      XDG_STATE_HOME: stateHome,
+    })
+
+    expect(fs.existsSync(path.join(dir, 'nex.log'))).toBe(true)
+  })
+
+  it('keeps stdout parseable under --json', async () => {
+    const {stdout} = await nex(
+      workdir,
+      ['health', 'check', '-a', 'no-such-alias-nex3', '--json'],
+      {XDG_STATE_HOME: stateHome},
+    )
+
+    // Anything winston puts on fd 1 breaks this, and would break MCP's JSON-RPC
+    // framing the same way.
+    if (stdout.trim().length > 0) {
+      expect(() => JSON.parse(stdout) as unknown).not.toThrow()
+    }
+  })
+
+  it('records something at --log-level trace instead of silently dropping everything', async () => {
+    const dir = path.join(workdir, 'trace-logs')
+    await nex(
+      workdir,
+      ['health', 'check', '-a', 'no-such-alias-nex3', '--log-dir', dir, '--log-level', 'trace'],
+      {XDG_STATE_HOME: stateHome},
+    )
+
+    // 'trace' is not a winston level. It used to leave the threshold undefined on
+    // the one transport that had no explicit level, so that transport dropped every
+    // record while the others kept working — partial and invisible.
+    expect(fs.readFileSync(path.join(dir, 'nex.log'), 'utf8').trim().length).toBeGreaterThan(0)
+  })
+
+  it('writes no credential material to the log', async () => {
+    const dir = path.join(workdir, 'secret-scan-logs')
+    await nex(
+      workdir,
+      ['health', 'check', '-a', 'no-such-alias-nex3', '--log-dir', dir, '--log-level', 'debug'],
+      {XDG_STATE_HOME: stateHome},
+    )
+
+    const contents = fs.readFileSync(path.join(dir, 'nex.log'), 'utf8')
+    for (const needle of ['JSESSIONID', 'glide_session_store', 'userToken', 'X-UserToken']) {
+      expect(contents).not.toContain(needle)
+    }
+  })
+})


### PR DESCRIPTION
Consumer side of [NEX-3](https://jengo.atlassian.net/browse/NEX-3). Requires core 6.0.0 (published, verified).

## Why

`nex` dropped `./logs/*.log` into whatever directory it was run from — including CI checkouts and any project a user happened to be standing in — with no flag, env var, or config to turn it off. The cause was in core, but the visible behaviour is the CLI's, and so is the fix.

## What changed

```
--log-file            write to $XDG_STATE_HOME/now-sdk-ext/logs
--log-dir <path>      write there instead; implies --log-file
```

`--log-dir` implies enable deliberately. Requiring both flags would make `--log-dir ./x` alone produce nothing, which reads as a broken flag rather than a missing second one.

`init()` now calls `configureLogging()` before creating any logger. That is the only thing that reaches core's ~43 loggers — they are field initializers taking no arguments, so a level passed to an individual `Logger` never applied to them, and **every core `.debug()` call was unreachable**. `--log-level debug` now works end to end.

It also fixes `--log-level trace`, which was not merely invalid: it left the threshold undefined on the one transport with no explicit level, so that transport dropped every record while the others kept working — partial and invisible.

Under `--json`, the console drops to `error` unless `--log-level` was passed explicitly, so piped stdout stays clean.

`flushLogs()` is awaited in `catch()` as well as `finally()`. `super.catch()` routes into oclif's error handler, which can terminate the process, so `finally()` is not guaranteed to run — and the line logged there is the failure, which is the one worth keeping. Without it the last record was lost intermittently (this showed up as a flaky test before being diagnosed).

## Verification

`test/common/logging-e2e.test.ts` spawns the real `bin/run.js` in a temp cwd and asserts no `logs/` appears, `--log-file` writes to the state dir, `--log-dir` opts in on its own, `--json` stdout parses, `--log-level trace` records something, and no credential markers reach the file. A flag-shape test would pass even if `configureLogging` were never called, which is the mistake worth guarding.

It strips `NODE_ENV` and `JEST_*` from the child — otherwise oclif loads TypeScript sources through ts-node and the test exercises something no user runs.

**557 tests pass against the published core 6.0.0**, and confirmed by hand from a clean directory: default run creates no `logs/`, `--log-file` writes only to the state dir.

## Note

`feat`, no `BREAKING CHANGE:` footer — should cut a minor (5.1.0). The new flags are additive; the behaviour change they gate lives in core's major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McPy1TWaokoHERpJCRcoc1

[NEX-3]: https://jengo.atlassian.net/browse/NEX-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ