### PR TITLE
chore(ci): let the review bot run on bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,10 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Without this the action refuses bot-authored PRs outright ("Workflow
+          # initiated by non-human actor"), so every Dependabot PR carried a red X
+          # that meant nothing — which is how people learn to merge past red checks.
+          allowed_bots: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
Sets `allowed_bots: '*'` on `claude-code-action`.

## Why

Every Dependabot PR failed the review job in ~9 seconds:

```
Action failed with error: Workflow initiated by non-human actor: dependabot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

That is the action's built-in guard, not a review verdict — so all 24 open Dependabot PRs carried a red X that meant nothing. A permanently-red check that never signals anything is worse than no check, because it teaches everyone to merge past red.

## Why bot PRs are worth actually reviewing

This last batch was not rubber-stampable. Two of 24 could not be merged as-is:

- **eslint 10** breaks `eslint-config-oclif`'s import resolver — `now-sdk-ext-cli` lint went 14 → **309 errors** (295 × `import/no-unresolved`). Notably `now-sdk-ext-core` took the *same* bump with zero change, because it has no import plugin.
- **jest 30** renamed `--testPathPattern` → `--testPathPatterns`, so merging it alone would have left `npm run test:unit` unable to start — no tests, rather than failing tests.

Both were caught by applying the bumps locally and running build/lint/test. A review on the PR is the cheaper place to catch the next one.

## Note on `*` vs a named list

`'*'` allows any bot, not just `dependabot[bot]`. That is what was asked for and is fine here given the action only posts reviews, but `allowed_bots: 'dependabot[bot]'` is the tighter option if you would rather not extend it to any future bot integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)