### PR TITLE
feat(cli): add --read-only / --deny-write / --deny-execute (NEX-99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,13 @@ A test placed outside those paths runs in neither.
 - `flushLogs()` is awaited in both `catch()` and `finally()`. Winston buffers, and
   `super.catch()` can terminate the process before `finally()` runs, which loses the
   failure line — the one worth keeping.
+- **Instance changes are permitted by default**; `--read-only` / `--deny-write` /
+  `--deny-execute` and `NEX_POLICY_DENY` take that away. Enforcement is in core at the
+  HTTP layer and decides per REQUEST, so commands need no per-command classification —
+  a command that reads or writes depending on its flags works with no special handling.
+  Do not add per-command gating.
+- The flags are deliberately deny-direction. `--allow-*` would grant nothing at a
+  permissive default and cannot override `NEX_POLICY_DENY`; a test asserts none exist.
 - Output goes through a display service; commands should not build tables inline.
 - `nex exec` is the only interactive surface (a REPL). `nex log` is a long-running
   tail with a SIGINT handler.

--- a/README.md
+++ b/README.md
@@ -681,6 +681,31 @@ USAGE
 ```
 <!-- usagestop -->
 
+
+## Restricting what can be changed
+
+Changes to a ServiceNow instance are **permitted by default**. Two ways to take that
+away, in priority order:
+
+| | | Reachable by an agent? |
+|---|---|---|
+| `NEX_POLICY_DENY=write,execute` (or `all`) | environment | **No** |
+| `--read-only`, `--deny-write`, `--deny-execute` | per invocation | Yes |
+
+Reads are never gated. `nex policy status` prints what is permitted and which layer
+decided — use it first when something is refused, since the fix differs completely
+between an environment variable and a flag.
+
+A malformed value **fails closed**: `NEX_POLICY_DENY=wrtie` denies everything and warns,
+rather than silently denying nothing.
+
+> `NEX_POLICY_DENY` holds only when set somewhere an agent cannot write — a shell
+> profile, a systemd unit, or a container environment. **Not** a committed `.env` or a
+> project-local config file, which anything with file access can edit.
+>
+> This is a guardrail, not a security boundary. Anything holding the credential can
+> reach the instance directly.
+
 # Commands
 <!-- commands -->
 * [`nex aggregate count`](#nex-aggregate-count)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@servicenow/sdk-cli": "4.9.2",
         "@servicenow/sdk-cli-core": "3.0.3",
         "@servicenow/sdk-core": "4.9.2",
-        "@sonisoft/now-sdk-ext-core": "^6.0.0",
+        "@sonisoft/now-sdk-ext-core": "^6.1.0",
         "@sonisoft/sn-credstore": "^1.0.0",
         "@ts-morph/common": "^0.24.0",
         "chalk": "^4.1.2",
@@ -12758,9 +12758,9 @@
       }
     },
     "node_modules/@sonisoft/now-sdk-ext-core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sonisoft/now-sdk-ext-core/-/now-sdk-ext-core-6.0.0.tgz",
-      "integrity": "sha512-5U4l9/L20uwjGR1MQnf8WP5Td5t/hEk4r+tt2sr98f7ooNF5bam3J2POGhC1aPJWzdfNsToHWWg49kAUhx4fGg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sonisoft/now-sdk-ext-core/-/now-sdk-ext-core-6.1.0.tgz",
+      "integrity": "sha512-B424HACgpVtGrnwh50Md/19pFBbiuqoQX4gTWsRu4Mp+1KfGV/6iV1yZhQAWYBVAvD84/ZhPqtSs3+n+YujDfQ==",
       "license": "MIT",
       "dependencies": {
         "@servicenow/glide": "^27.0.5",
@@ -12771,6 +12771,7 @@
         "@servicenow/sdk-core": "4.9.2",
         "@ts-morph/common": "^0.24.0",
         "@xmldom/xmldom": "^0.8.10",
+        "acorn": "^8.18.0",
         "async": "3.2.6",
         "bluebird": "3.7.2",
         "cometd": "^9.0.0",
@@ -14316,9 +14317,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"

--- a/package.json
+++ b/package.json
@@ -105,26 +105,56 @@
     ],
     "topicSeparator": " ",
     "topics": {
-      "atf": {
-        "description": "Execute ATF (Automated Test Framework) tests and test suites on a ServiceNow instance."
+      "aggregate": {
+        "description": "Run aggregate statistics (COUNT, AVG, MIN, MAX, SUM) on ServiceNow tables with optional grouping."
       },
       "app": {
         "description": "Operations on ServiceNow Applications."
       },
+      "atf": {
+        "description": "Execute ATF (Automated Test Framework) tests and test suites on a ServiceNow instance."
+      },
+      "attachment": {
+        "description": "Manage attachments on ServiceNow records."
+      },
+      "batch": {
+        "description": "Perform batch create and update operations on ServiceNow records."
+      },
+      "bulk": {
+        "description": "Bulk update or delete ServiceNow records matching an encoded query (dry-run by default)."
+      },
       "exec": {
         "description": "Execute scripts remotely on a ServiceNow instance. Immitates using Scripts - Background from within ServiceNow."
+      },
+      "flow": {
+        "description": "Execute and manage Flow Designer flows, subflows, and actions on a ServiceNow instance."
+      },
+      "health": {
+        "description": "Run consolidated health checks and diagnostics on a ServiceNow instance."
       },
       "log": {
         "description": "Tail and monitor ServiceNow system logs in real-time."
       },
-      "search": {
-        "description": "Search platform code across ServiceNow instances."
+      "policy": {
+        "description": "Inspect what this invocation may change on the instance."
+      },
+      "query": {
+        "description": "Query ServiceNow tables, search applications, list columns, and read syslog records."
       },
       "schema": {
         "description": "Discover and inspect ServiceNow table schemas and field definitions."
       },
+      "scope": {
+        "description": "Manage ServiceNow application scopes."
+      },
       "script-sync": {
         "description": "Synchronize scripts between local files and ServiceNow instances."
+      },
+      "search": {
+        "description": "Search platform code across ServiceNow instances."
+      },
+      "store": {
+        "description": "Search, install, and update applications from the ServiceNow Store."
       },
       "task": {
         "description": "Perform operations on ServiceNow tasks, incidents, and change requests."
@@ -134,33 +164,6 @@
       },
       "workflow": {
         "description": "Create and manage ServiceNow workflows."
-      },
-      "attachment": {
-        "description": "Manage attachments on ServiceNow records."
-      },
-      "scope": {
-        "description": "Manage ServiceNow application scopes."
-      },
-      "batch": {
-        "description": "Perform batch create and update operations on ServiceNow records."
-      },
-      "store": {
-        "description": "Search, install, and update applications from the ServiceNow Store."
-      },
-      "query": {
-        "description": "Query ServiceNow tables, search applications, list columns, and read syslog records."
-      },
-      "aggregate": {
-        "description": "Run aggregate statistics (COUNT, AVG, MIN, MAX, SUM) on ServiceNow tables with optional grouping."
-      },
-      "health": {
-        "description": "Run consolidated health checks and diagnostics on a ServiceNow instance."
-      },
-      "bulk": {
-        "description": "Bulk update or delete ServiceNow records matching an encoded query (dry-run by default)."
-      },
-      "flow": {
-        "description": "Execute and manage Flow Designer flows, subflows, and actions on a ServiceNow instance."
       },
       "xml": {
         "description": "Export and import ServiceNow records as XML."

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@servicenow/sdk-cli": "4.9.2",
     "@servicenow/sdk-cli-core": "3.0.3",
     "@servicenow/sdk-core": "4.9.2",
-    "@sonisoft/now-sdk-ext-core": "^6.0.0",
+    "@sonisoft/now-sdk-ext-core": "^6.1.0",
     "@sonisoft/sn-credstore": "^1.0.0",
     "@ts-morph/common": "^0.24.0",
     "chalk": "^4.1.2",

--- a/src/commands/policy/status.ts
+++ b/src/commands/policy/status.ts
@@ -1,0 +1,78 @@
+import {Command, Flags} from '@oclif/core'
+import {checkRequirement, currentLayers, DENY_ENV, type Verb} from '@sonisoft/now-sdk-ext-core'
+
+import {installCliPolicy, type PolicyFlags} from '../../common/policy.js'
+
+/**
+ * Reports what this invocation is permitted to do, and which layer decided.
+ *
+ * Exists because precedence bugs are otherwise invisible: a user sees "refused" with no
+ * way to tell whether the environment denied it, a flag denied it, or nothing granted
+ * it — and the fix is completely different in each case.
+ *
+ * Extends plain `Command`, not `AuthenticatedCommand`: answering "what may I do" must
+ * not require working credentials. Someone diagnosing a refusal should not have to get
+ * past auth first.
+ */
+export default class PolicyStatus extends Command {
+  static description =
+    'Show what this invocation is permitted to change on the instance, and why.\n\n' +
+    'Changes are permitted by default. NEX_POLICY_DENY, set in the environment, ' +
+    'outranks every command-line flag — that is the only layer an agent driving this ' +
+    'CLI cannot reach.'
+static enableJsonFlag = true
+static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --read-only',
+    'NEX_POLICY_DENY=all <%= config.bin %> <%= command.id %>',
+  ]
+static flags = {
+    'deny-execute': Flags.boolean({description: 'Evaluate as if --deny-execute were passed.'}),
+    'deny-write': Flags.boolean({description: 'Evaluate as if --deny-write were passed.'}),
+    'read-only': Flags.boolean({description: 'Evaluate as if --read-only were passed.'}),
+  }
+
+  public async run(): Promise<{permitted: Record<string, unknown>; source: string}> {
+    const {flags} = await this.parse(PolicyStatus)
+
+    const warnings: string[] = []
+    installCliPolicy(flags as PolicyFlags, (m) => warnings.push(m))
+
+    const verbs: Verb[] = ['write', 'execute']
+    const permitted: Record<string, unknown> = {}
+    for (const verb of verbs) {
+      const decision = checkRequirement({target: 'instance', verbs: [verb]})
+      permitted[verb] = {allowed: decision.allowed, decidedBy: decision.decidingLayer}
+    }
+
+    const envSet = Boolean(process.env[DENY_ENV])
+    const result = {permitted, source: envSet ? `${DENY_ENV} is set` : 'no environment lockdown'}
+
+    if (!this.jsonEnabled()) {
+      this.log('Instance changes')
+      for (const verb of verbs) {
+        const entry = permitted[verb] as {allowed: boolean; decidedBy: string}
+        const mark = entry.allowed ? 'permitted' : 'REFUSED  '
+        this.log(`  ${verb.padEnd(8)} ${mark}  (${entry.decidedBy})`)
+      }
+
+      this.log('')
+      this.log('Reads are never gated.')
+      this.log(
+        envSet
+          ? `${DENY_ENV} is set in the environment and outranks every flag.`
+          : `${DENY_ENV} is not set. Set it in your shell profile or container ` +
+            `environment to deny changes in a way a command-line flag cannot undo.`,
+      )
+
+      // Ordered, because the order IS the behaviour.
+      this.log('')
+      this.log('Layers, highest priority first:')
+      for (const layer of currentLayers()) this.log(`  ${layer.name}`)
+
+      for (const warning of warnings) this.warn(warning)
+    }
+
+    return result
+  }
+}

--- a/src/common/authenticated-command.ts
+++ b/src/common/authenticated-command.ts
@@ -2,9 +2,10 @@
 
 import { Command, Flags, Interfaces } from '@oclif/core'
 import { getCredentials } from "@servicenow/sdk-cli/dist/auth/index.js";
-import { configureLogging, flushLogs, Logger, ServiceNowInstance, ServiceNowSettingsInstance } from '@sonisoft/now-sdk-ext-core';
+import { configureLogging, flushLogs, isPolicyRefusal, Logger, ServiceNowInstance, ServiceNowSettingsInstance } from '@sonisoft/now-sdk-ext-core';
 
 import { LogFactory } from '../util/log-factory.js';
+import { installCliPolicy, type PolicyFlags } from './policy.js';
 
 
 
@@ -22,6 +23,26 @@ export abstract class AuthenticatedCommand<T extends typeof Command> extends Com
     'cred-store': Flags.boolean({
       description: 'Read credentials from @sonisoft/sn-credstore instead of the OS keyring. ' +
         'Use this in headless sessions (SSH, systemd, CI, agents) where the keyring cannot be unlocked.',
+      helpGroup: 'GLOBAL',
+      required: false,
+    }),
+    // Changes are PERMITTED by default; these take permission away.
+    //
+    // Deliberately deny-direction rather than `--allow-write`. With a permissive
+    // default an allow-flag would grant nothing it did not already have, and it could
+    // not override NEX_POLICY_DENY either, so it would ship as a no-op. If the default
+    // ever flips to deny, the allow flags arrive in that same change.
+    //
+    // These are agent-reachable, which is fine: an agent can only ever RESTRICT itself
+    // with them. The layer an agent cannot reach is NEX_POLICY_DENY, which outranks
+    // every flag — that is what makes pointing nex at production meaningful.
+    'deny-execute': Flags.boolean({
+      description: 'Refuse background scripts, flow runs and ATF runs for this invocation.',
+      helpGroup: 'GLOBAL',
+      required: false,
+    }),
+    'deny-write': Flags.boolean({
+      description: 'Refuse any change to instance data for this invocation.',
       helpGroup: 'GLOBAL',
       required: false,
     }),
@@ -47,6 +68,12 @@ export abstract class AuthenticatedCommand<T extends typeof Command> extends Com
       summary: 'Specify level for logging.',
 
     })(),
+    'read-only': Flags.boolean({
+      description: 'Refuse every change to the instance — equivalent to ' +
+        '--deny-write --deny-execute. Reads are unaffected.',
+      helpGroup: 'GLOBAL',
+      required: false,
+    }),
   }
 // add the --json flag
     static enableJsonFlag = true
@@ -65,6 +92,20 @@ protected instance!:ServiceNowInstance;
     }
 
   protected async catch(err: Error & {exitCode?: number}): Promise<any> {
+    // A refusal is a decision, not a crash. Render it as the CLI's own error with
+    // remediation, rather than letting a stack trace reach the user for something they
+    // asked for by passing a flag. Handled first, before the generic path below.
+    if (isPolicyRefusal(err)) {
+      this.authLogger?.warn("Refused by policy.", {message: err.message});
+      await flushLogs();
+      this.error(err.message, {
+        suggestions: [
+          'Reads are unaffected — only changes to the instance were refused.',
+          'Run `nex policy status` to see what is permitted and which layer decided.',
+        ],
+      });
+    }
+
     // authLogger is assigned partway through init(), so anything that throws
     // before that point — a missing required flag, for instance — arrived here
     // with it still undefined and produced "Cannot read properties of undefined
@@ -123,6 +164,15 @@ protected instance!:ServiceNowInstance;
 
     this.logger = LogFactory.createLogger(this.ctor.name);
     this.authLogger = LogFactory.createLogger("AuthenticatedCommand");
+
+    // Install the permission ladder before anything can issue a request. Core's gate
+    // is inert until this runs, so ordering matters: after logging (so a malformed
+    // NEX_POLICY_DENY has somewhere to warn) and before the first credential fetch.
+    //
+    // Note there is no per-command classification. The gate sits at the HTTP layer and
+    // decides per REQUEST, so `update-set current` reading or writing depending on
+    // --set, and `script-sync sync` going both ways, need no special handling here.
+    installCliPolicy(this.flags as PolicyFlags, (message) => this.authLogger.warn(message));
     // const wrapper:CredentialWrapper = new CredentialWrapper();
     // const credential:Creds = await (flags.auth ? wrapper.getStoredCredentialsByAlias(flags.auth) : wrapper.getStoredCredentialsByAlias( 'fluent-default'));
     // const credentialArgs = {"_": "get-credentials", auth: flags.auth || "fluent-default"};

--- a/src/common/policy.ts
+++ b/src/common/policy.ts
@@ -1,0 +1,108 @@
+import {
+  
+  allowFromEnvironment,
+  DENY_ENV,
+  denyFromEnvironment,
+  denyLayer,
+  grantLayer,
+  installPolicy,
+  type PolicyLayer,
+  setRemediationWriter,
+  Verb,
+} from '@sonisoft/now-sdk-ext-core'
+
+/**
+ * Builds and installs the permission ladder for one `nex` invocation.
+ *
+ * Changes are PERMITTED by default. This is not the strongest posture available — an
+ * agent that decides to run `nex bulk delete` still just does it — but it is the one
+ * that does not break every existing script and CI job, and the machinery is arranged
+ * so flipping is a one-line change (see DEFAULT_ALLOW below).
+ *
+ * What it does buy today: `NEX_POLICY_DENY`, set somewhere the agent cannot write,
+ * outranks every flag. That is the difference between "the agent probably will not
+ * write to prod" and "the agent cannot".
+ */
+
+export interface PolicyFlags {
+  'deny-execute'?: boolean
+  'deny-write'?: boolean
+  'read-only'?: boolean
+}
+
+/** The verbs a set of flags takes away. */
+export function deniedByFlags(flags: PolicyFlags): Verb[] {
+  const denied = new Set<Verb>()
+  if (flags['read-only']) {
+    denied.add('write')
+    denied.add('execute')
+  }
+
+  if (flags['deny-write']) denied.add('write')
+  if (flags['deny-execute']) denied.add('execute')
+  return [...denied]
+}
+
+/**
+ * Assembles the ladder, highest priority first.
+ *
+ * Order is the whole design. `NEX_POLICY_DENY` sits above the flags so a flag cannot
+ * grant past it; the permissive default sits at the bottom so anything above it can
+ * take permission away.
+ */
+export function buildLayers(flags: PolicyFlags, warn: (message: string) => void): PolicyLayer[] {
+  const layers: PolicyLayer[] = []
+
+  // 0. Operator lockdown. The only rung an agent cannot reach — and only when set
+  //    somewhere it cannot write. A project-local .mcp.json or a committed .env is
+  //    still editable by anything with file access; a shell profile is not.
+  const envDeny = denyFromEnvironment(process.env, warn)
+  if (envDeny) layers.push(envDeny)
+
+  // 1. Per-invocation denials. Agent-reachable, but they only ever restrict.
+  const flagDenied = deniedByFlags(flags)
+  if (flagDenied.length > 0) layers.push(denyLayer('command-line flag', flagDenied))
+
+  // 2. Grants from the environment. Inert while the default is permissive; kept in
+  //    place so the ladder does not have to be rebuilt when the default flips.
+  const envAllow = allowFromEnvironment(process.env, warn)
+  if (envAllow) layers.push(envAllow)
+
+  // 3. THE DEFAULT. Delete this one layer to make `nex` deny-by-default; everything
+  //    above keeps working unchanged.
+  layers.push(grantLayer('default (changes permitted)', ['write', 'execute']))
+
+  return layers
+}
+
+/**
+ * Explains a refusal in terms of what the user can actually do about it.
+ *
+ * Names the deciding layer, because "refused" without "by what" is unactionable — and
+ * the fix differs completely: unset an environment variable, or drop a flag.
+ */
+function remediation(verbs: readonly Verb[], missing: Verb, layer: string): string {
+  const what = missing === 'execute' ? 'running scripts or flows' : 'changing instance data'
+
+  if (layer.startsWith(DENY_ENV)) {
+    return `Refused: ${what} is denied by ${DENY_ENV}. ` +
+      `This is set in the environment, not on the command line — unset it there to allow this.`
+  }
+
+  if (layer === 'command-line flag') {
+    return `Refused: ${what} is denied by a flag on this command. ` +
+      `Remove --read-only / --deny-${missing} to allow it.`
+  }
+
+  return `Refused: ${what} is not permitted (${layer}).`
+}
+
+/** Installs the policy for this process. Call once, from init(), before any request. */
+export function installCliPolicy(flags: PolicyFlags, warn: (message: string) => void): void {
+  installPolicy(buildLayers(flags, warn))
+  setRemediationWriter(remediation)
+}
+
+
+
+export {ALLOW_ENV, DENY_ENV} from '@sonisoft/now-sdk-ext-core'

--- a/test/common/policy-e2e.test.ts
+++ b/test/common/policy-e2e.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The permission surface, through the real binary.
+ *
+ * A unit test on `buildLayers` passes even if `init()` never installs the policy — so
+ * these spawn `bin/run.js` and assert on what a user actually gets. `nex policy status`
+ * is used as the probe because it needs no credentials, which keeps these runnable in
+ * any checkout rather than only where an instance is configured.
+ */
+
+import {describe, it, expect} from '@jest/globals'
+import {execFile} from 'node:child_process'
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import {promisify} from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const REPO = process.cwd()
+const RUN = path.join(REPO, 'bin', 'run.js')
+const BUILT = fs.existsSync(path.join(REPO, 'dist', 'commands'))
+
+async function nex(args: string[], env: NodeJS.ProcessEnv = {}): Promise<{stdout: string; stderr: string}> {
+  // Jest sets NODE_ENV/JEST_*, and oclif reads those to decide it should load
+  // TypeScript sources through ts-node instead of dist/ — testing something no user runs.
+  const childEnv = {...process.env, ...env}
+  delete childEnv.NODE_ENV
+  for (const key of Object.keys(childEnv)) if (key.startsWith('JEST_')) delete childEnv[key]
+
+  try {
+    return await execFileAsync(process.execPath, [RUN, ...args], {env: childEnv, timeout: 60_000})
+  } catch (error) {
+    const e = error as {stdout?: string; stderr?: string}
+    return {stderr: e.stderr ?? '', stdout: e.stdout ?? ''}
+  }
+}
+
+const maybe = BUILT ? describe : describe.skip
+
+maybe('nex policy status', () => {
+  it('permits changes by default', async () => {
+    const {stdout} = await nex(['policy', 'status'], {NEX_POLICY_DENY: ''})
+    expect(stdout).toMatch(/write\s+permitted/)
+    expect(stdout).toMatch(/execute\s+permitted/)
+  }, 90_000)
+
+  it('refuses both verbs under --read-only', async () => {
+    const {stdout} = await nex(['policy', 'status', '--read-only'], {NEX_POLICY_DENY: ''})
+    expect(stdout).toMatch(/write\s+REFUSED/)
+    expect(stdout).toMatch(/execute\s+REFUSED/)
+  }, 90_000)
+
+  it('refuses only the named verb under --deny-write', async () => {
+    const {stdout} = await nex(['policy', 'status', '--deny-write'], {NEX_POLICY_DENY: ''})
+    expect(stdout).toMatch(/write\s+REFUSED/)
+    expect(stdout).toMatch(/execute\s+permitted/)
+  }, 90_000)
+
+  it('lets the environment refuse what no flag asked to refuse', async () => {
+    const {stdout} = await nex(['policy', 'status'], {NEX_POLICY_DENY: 'write'})
+    expect(stdout).toMatch(/write\s+REFUSED/)
+    expect(stdout).toContain('NEX_POLICY_DENY')
+  }, 90_000)
+
+  it('FAILS CLOSED on a malformed environment value', async () => {
+    // A typo in the variable protecting production must not quietly protect nothing.
+    const {stdout} = await nex(['policy', 'status'], {NEX_POLICY_DENY: 'wrtie'})
+    expect(stdout).toMatch(/write\s+REFUSED/)
+    expect(stdout).toMatch(/execute\s+REFUSED/)
+  }, 90_000)
+
+  it('names the deciding layer, so a refusal is diagnosable', async () => {
+    const {stdout} = await nex(['policy', 'status', '--read-only'], {NEX_POLICY_DENY: ''})
+    expect(stdout).toContain('command-line flag')
+  }, 90_000)
+
+  it('emits parseable JSON under --json', async () => {
+    const {stdout} = await nex(['policy', 'status', '--json'], {NEX_POLICY_DENY: 'all'})
+    const parsed = JSON.parse(stdout) as {permitted: Record<string, {allowed: boolean}>}
+    expect(parsed.permitted.write.allowed).toBe(false)
+    expect(parsed.permitted.execute.allowed).toBe(false)
+  }, 90_000)
+})
+
+maybe('global flags reach every command', () => {
+  it('offers the deny flags in help for an unrelated command', async () => {
+    // baseFlags inheritance is the mechanism; this proves it reaches a real command
+    // rather than only the base class.
+    const {stdout, stderr} = await nex(['query', '--help'])
+    const help = stdout + stderr
+    expect(help).toContain('--read-only')
+    expect(help).toContain('--deny-write')
+    expect(help).toContain('--deny-execute')
+  }, 90_000)
+
+  it('does not advertise allow flags while the default is permissive', async () => {
+    const {stdout, stderr} = await nex(['query', '--help'])
+    expect(stdout + stderr).not.toContain('--allow-write')
+  }, 90_000)
+})

--- a/test/common/policy-unit.test.ts
+++ b/test/common/policy-unit.test.ts
@@ -1,0 +1,101 @@
+import {expect, describe, it, afterEach} from '@jest/globals'
+import {checkRequirement, installPolicy, resetPolicyForTests} from '@sonisoft/now-sdk-ext-core'
+
+import {AuthenticatedCommand} from '../../src/common/authenticated-command.js'
+import {buildLayers, deniedByFlags} from '../../src/common/policy.js'
+
+/**
+ * The permission ladder as the CLI assembles it.
+ *
+ * Changes are permitted by default; flags and the environment take permission AWAY.
+ * The order of the ladder is the behaviour, so most of these are ordering assertions.
+ */
+
+const noWarn = () => undefined
+
+afterEach(() => resetPolicyForTests())
+
+describe('deny flags', () => {
+  it('denies nothing when no flag is passed', () => {
+    expect(deniedByFlags({})).toEqual([])
+  })
+
+  it.each([
+    [{'deny-write': true}, ['write']],
+    [{'deny-execute': true}, ['execute']],
+    [{'deny-execute': true, 'deny-write': true}, ['write', 'execute']],
+  ])('maps %o', (flags, expected) => {
+    expect(deniedByFlags(flags).sort()).toEqual([...expected].sort())
+  })
+
+  it('treats --read-only as both', () => {
+    expect(deniedByFlags({'read-only': true}).sort()).toEqual(['execute', 'write'])
+  })
+
+  it('does not double-count when --read-only is combined with a specific deny', () => {
+    expect(deniedByFlags({'deny-write': true, 'read-only': true}).sort()).toEqual(['execute', 'write'])
+  })
+})
+
+describe('default posture', () => {
+  it('permits changes when nothing denies', () => {
+    installPolicy(buildLayers({}, noWarn))
+    expect(checkRequirement({target: 'instance', verbs: ['write']}).allowed).toBe(true)
+    expect(checkRequirement({target: 'instance', verbs: ['execute']}).allowed).toBe(true)
+  })
+
+  it('names the default layer, so `policy status` can explain itself', () => {
+    installPolicy(buildLayers({}, noWarn))
+    expect(checkRequirement({target: 'instance', verbs: ['write']}).decidingLayer).toMatch(/default/)
+  })
+
+  it('keeps the permissive default LAST, so anything above can revoke', () => {
+    // If the default layer ever moved up the ladder it would grant before the deny
+    // layers were consulted, and every flag would silently stop working.
+    const layers = buildLayers({'read-only': true}, noWarn)
+    expect(layers.at(-1)?.name).toMatch(/default/)
+  })
+})
+
+describe('flags revoke', () => {
+  it('refuses write under --deny-write', () => {
+    installPolicy(buildLayers({'deny-write': true}, noWarn))
+    expect(checkRequirement({target: 'instance', verbs: ['write']}).allowed).toBe(false)
+    expect(checkRequirement({target: 'instance', verbs: ['execute']}).allowed).toBe(true)
+  })
+
+  it('refuses everything under --read-only', () => {
+    installPolicy(buildLayers({'read-only': true}, noWarn))
+    expect(checkRequirement({target: 'instance', verbs: ['write']}).allowed).toBe(false)
+    expect(checkRequirement({target: 'instance', verbs: ['execute']}).allowed).toBe(false)
+  })
+
+  it('never gates reads', () => {
+    installPolicy(buildLayers({'read-only': true}, noWarn))
+    expect(checkRequirement({target: 'instance', verbs: []}).allowed).toBe(true)
+  })
+})
+
+describe('flag surface', () => {
+  it('declares the deny flags in GLOBAL', () => {
+    for (const name of ['deny-write', 'deny-execute', 'read-only']) {
+      const flag = (AuthenticatedCommand.baseFlags as Record<string, {helpGroup?: string}>)[name]
+      expect(flag).toBeDefined()
+      expect(flag.helpGroup).toBe('GLOBAL')
+    }
+  })
+
+  it('declares NO --allow-* flags while the default is permissive', () => {
+    // They would grant nothing they did not already have, and could not override
+    // NEX_POLICY_DENY either — so they would ship as no-ops. They arrive in the same
+    // change that flips the default.
+    const names = Object.keys(AuthenticatedCommand.baseFlags)
+    expect(names.filter((n) => n.startsWith('allow-'))).toEqual([])
+  })
+
+  it('uses kebab-case only, matching how oclif keys parsed flags', () => {
+    const names = Object.keys(AuthenticatedCommand.baseFlags)
+    expect(names).toEqual(expect.arrayContaining(['deny-write', 'deny-execute', 'read-only']))
+    for (const camel of ['denyWrite', 'denyExecute', 'readOnly']) expect(names).not.toContain(camel)
+  })
+})


### PR DESCRIPTION
Consumer side of [NEX-96](https://jengo.atlassian.net/browse/NEX-96). Covers [NEX-99](https://jengo.atlassian.net/browse/NEX-99). Requires core 6.1.0 — published and verified.

Changes to the instance are **permitted by default**; these flags take permission away. Not breaking, so this is a minor.

```
--read-only        refuse every change (reads unaffected)
--deny-write       refuse changes to instance data
--deny-execute     refuse background scripts, flow runs, ATF runs
NEX_POLICY_DENY    same, from the environment — outranks every flag
```

## Why deny-direction and not `--allow-*`

At a permissive default an allow-flag grants nothing it did not already have, and it cannot override `NEX_POLICY_DENY` either — it would ship as a no-op. The allow flags arrive in whatever change flips the default. **A test asserts none exist today**, so that stays a decision rather than an oversight.

The deny flags are agent-reachable, which is fine: an agent can only ever **restrict itself** with them. The layer an agent cannot reach is `NEX_POLICY_DENY`.

**What this does not buy at the permissive default:** inadvertent mutation is still permitted. An agent that decides to run `nex bulk delete` still does. What it buys is that an operator can point `nex` at production and know the agent cannot grant past the environment.

## The branch-level problem dissolved

The plan called for per-command classification and special handling for `update-set current` (reads or writes on `--set`), `script-sync sync` (bidirectional) and `app --uninstall`. With enforcement in core at the HTTP layer deciding per **request**, none of it was needed — **no command file was touched**.

One declaration in `baseFlags` reaches all 67 authenticated commands via oclif's static inheritance, including the re-parse most do in `run()`.

## Refusal UX

Rendered through `this.error` with remediation naming the **deciding layer** — "refused" without "by what" is unactionable, and the fix is completely different for an environment variable than for a flag.

`nex policy status` extends plain `Command`, not `AuthenticatedCommand`: diagnosing a refusal must not require working credentials first.

## Verification — against a live instance, not only unit tests

| | |
|---|---|
| read under `--read-only` | works |
| read-only script, default | runs |
| same script, `--read-only` | refused, names the flag to remove |
| `gr.insert()` script, `--deny-write` | refused — `"detected":["calls .insert()"]`, execute still permitted |
| `NEX_POLICY_DENY=all`, no flags | refused, names the env var |
| `NEX_POLICY_DENY=wrtie` | **fails closed** — denies everything |

That fourth row is the script scanner working end to end: it found the mutation, required `write` on top of `execute`, and told the user exactly what it saw.

**581 unit tests** against the published core 6.1.0, 9 of them spawning the real binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01McPy1TWaokoHERpJCRcoc1

[NEX-96]: https://jengo.atlassian.net/browse/NEX-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEX-99]: https://jengo.atlassian.net/browse/NEX-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ